### PR TITLE
Add cross platform CI and a parallel backend test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,136 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pipeline:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # The version renv.lock was built against. Package binaries on Posit
+      # Package Manager are keyed on the R minor version, so this keeps all
+      # three platforms installing binaries rather than compiling.
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.6.1'
+
+      - uses: r-lib/actions/setup-renv@v2
+
+      - name: Report the environment
+        shell: bash
+        run: Rscript -e 'sessionInfo(); cat("cores:", parallel::detectCores(), "\n")'
+
+      # The cluster backend on its own. When this fails the message points at
+      # worker startup instead of at whichever calibration happened to run first.
+      - name: Parallel backend, platform default
+        shell: bash
+        run: Rscript test-parallel.R
+
+      # PSOCK is what Windows gets. Running it on Linux and macOS as well means a
+      # bootstrap that only works under FORK gets caught on every platform.
+      - name: Parallel backend, forced PSOCK
+        if: runner.os != 'Windows'
+        shell: bash
+        run: Rscript test-parallel.R PSOCK
+
+      # Iteration counts here are far below a usable calibration. The point is to
+      # drive every parallel path end to end, not to converge on anything.
+      - name: Calibrate 1 zone, period of record
+        shell: bash
+        run: Rscript run-controller.R --dir runs/1zone --basin FSSO3 --objfun kge_NULL --iterations 100 --num_cores 2 --overwrite
+
+      - name: Calibrate 1 zone, cross validation folds
+        shell: bash
+        run: |
+          for fold in 1 2 3 4; do
+            Rscript run-controller.R --dir runs/1zone --basin FSSO3 --objfun kge_NULL \
+              --cvfold "$fold" --iterations 100 --num_cores 2 --overwrite
+          done
+
+      - name: Postprocess 1 zone
+        shell: bash
+        run: Rscript postprocess.R --dir runs/1zone --basins FSSO3
+
+      # cv-plots.R builds its own cluster and bootstrap, separately from the one
+      # in ep_dds, so it needs covering too.
+      - name: Cross validation plots
+        shell: bash
+        run: Rscript cv-plots.R --dir runs/1zone --basins FSSO3
+
+      # SFLN2 has a consumptive use zone and channel loss, SAKW1 routes an
+      # upstream point through lagk. Between them they reach the model paths
+      # FSSO3 does not.
+      - name: Calibrate 2 zone with consumptive use
+        shell: bash
+        run: Rscript run-controller.R --dir runs/2zone --basin SFLN2 --objfun lognse_kge --iterations 100 --num_cores 2 --overwrite
+
+      - name: Calibrate 2 zone with upstream routing
+        shell: bash
+        run: Rscript run-controller.R --dir runs/2zone --basin SAKW1 --objfun lognse_kge --iterations 100 --num_cores 2 --overwrite
+
+      - name: Check the expected outputs exist
+        shell: bash
+        run: |
+          set -e
+          for f in runs/1zone/FSSO3/results_por_01/pars_optimal.csv \
+                   runs/1zone/FSSO3/results_por_01/run_summary.txt \
+                   runs/1zone/FSSO3/results_por_01/optimal_daily.csv \
+                   runs/1zone/FSSO3/results_cv_4_01/pars_optimal.csv \
+                   runs/1zone/cv_plots/FSSO3_CV_Plot.png \
+                   runs/2zone/SFLN2/results_por_01/pars_optimal.csv \
+                   runs/2zone/SAKW1/results_por_01/pars_optimal.csv; do
+            if [ ! -s "$f" ]; then echo "missing or empty: $f"; exit 1; fi
+            echo "ok: $f"
+          done
+
+      # Only the generated output, the basin inputs are already in the repo.
+      - name: Upload run output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runs-${{ matrix.os }}
+          path: |
+            runs/**/results_*/
+            runs/**/cv_plots/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  metrics:
+    name: metrics vs hydroGOF
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.6.1'
+
+      - uses: r-lib/actions/setup-renv@v2
+
+      # hydroGOF is GPL and this project is Apache 2.0, so it is not a dependency
+      # and renv is set to ignore it. It is installed here only to check the
+      # implementations in R/metrics.R against it.
+      - name: Install hydroGOF
+        run: Rscript -e 'renv::install("hydroGOF")'
+
+      - name: Compare metrics against hydroGOF
+        run: Rscript R/test-metrics.R

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -1,0 +1,35 @@
+# Worker cluster construction, shared by the EDDS optimizer in wrappers.R and
+# the cross validation bootstrap in cv-plots.R.
+#
+# Written by Cameron Bracken and Geoffrey Walters (2025)
+# Please see the LICENSE file for license information
+
+box::use(
+  parallel[makeCluster]
+)
+
+#' Build the worker cluster.
+#'
+#' FORK on Linux and macOS, which is cheaper because workers inherit the
+#' master's memory, and PSOCK on Windows, which has no fork.
+#'
+#' Since R 4.0 makePSOCKcluster starts every worker at once by default. It is
+#' faster, but a worker occasionally fails to connect, and the master then sits
+#' out the full connection timeout, several minutes, before giving up and taking
+#' the calibration with it. Starting the workers one at a time avoids that. The
+#' extra cost is roughly a second at the start of a run that takes hours.
+#'
+#' @param n_cores number of workers to start
+#' @param type cluster type, defaults to the right one for the platform. Only
+#'   set it to check the PSOCK path on a machine that would otherwise fork.
+#' @export
+make_worker_cluster <- function(n_cores, type = NULL) {
+  if (is.null(type)) {
+    type <- if (.Platform$OS.type == "windows") "PSOCK" else "FORK"
+  }
+  if (identical(type, "PSOCK")) {
+    makeCluster(n_cores, type = "PSOCK", setup_strategy = "sequential")
+  } else {
+    makeCluster(n_cores, type = type)
+  }
+}

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -9,8 +9,9 @@ box::use(
              rbindlist, nafill],
   tibble[as_tibble],
   tidyr[fill],
-  parallel[makeCluster, clusterSetRNGStream, clusterCall,
+  parallel[clusterSetRNGStream, clusterCall,
              clusterEvalQ, clusterExport, stopCluster],
+  ./cluster[make_worker_cluster],
   ./metrics[NSE, pbias, rPearson, KGE],
   nwsrfsr[sac_snow_uh, sac_snow_uh_lagk, lagk, chanloss,
           consuse, fa_nwrfc],
@@ -291,9 +292,8 @@ ep_dds <- function(fn, p_bounds, t_iter = 1000, n_cores = 4, r = 0.2, ...) {
   list2env(list(...), environment())
 
   # Parallel Registration
-  # Use FORK on Linux/Mac for maximum speed, fallback to PSOCK for Windows compatibility
-  os_type <- if (.Platform$OS.type == "windows") "PSOCK" else "FORK"
-  my_cluster <- makeCluster(n_cores, type = os_type)
+  # FORK on Linux/Mac for maximum speed, PSOCK on Windows, see R/cluster.R
+  my_cluster <- make_worker_cluster(n_cores)
   # Seeding using L'Ecuyer-CMRG
   RNGkind("L'Ecuyer-CMRG")
   clusterSetRNGStream(cl = my_cluster, iseed = NULL)

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -4,12 +4,12 @@
 box::use(
   stats[runif, rnorm, setNames],
   dplyr[filter, select, summarise, group_by, ungroup, mutate,
-        lead, right_join, bind_rows],
+        lag, lead, right_join, bind_rows],
   data.table[as.data.table, data.table, merge.data.table, copy,
              rbindlist, nafill],
   tibble[as_tibble],
   tidyr[fill],
-  parallel[makeCluster, clusterSetRNGStream, clusterCall, 
+  parallel[makeCluster, clusterSetRNGStream, clusterCall,
              clusterEvalQ, clusterExport, stopCluster],
   ./metrics[NSE, pbias, rPearson, KGE],
   nwsrfsr[sac_snow_uh, sac_snow_uh_lagk, lagk, chanloss,
@@ -250,11 +250,11 @@ model_wrapper <- function(p, p_names, dt_hours, default_pars, obs_daily, obs_ins
 run_controller_edds <- function(lower, upper, basin, dt_hours, default_pars,
                                 obs_daily, obs_inst, forcing, upflow = NULL,
                                 obj_fun = "rmse", n_zones, cu_zones = character(0),
-                                n_cores, lite = FALSE) {
+                                n_cores, lite = FALSE, t_iter = NULL) {
   # browser()
   # ptm = proc.time()
 
-  t_iter <- ifelse(lite, 2500, 5000)
+  if (is.null(t_iter) || is.na(t_iter)) t_iter <- ifelse(lite, 2500, 5000)
 
   out <- ep_dds(
     fn = model_wrapper,
@@ -311,7 +311,7 @@ ep_dds <- function(fn, p_bounds, t_iter = 1000, n_cores = 4, r = 0.2, ...) {
     box::use(
       stats[runif, rnorm, setNames],
       dplyr[filter, select, summarise, group_by, ungroup, mutate,
-            lead, right_join, bind_rows],
+            lag, lead, right_join, bind_rows],
       data.table[as.data.table, data.table, merge.data.table, copy,
                  rbindlist, nafill],
       tibble[as_tibble],

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cv-plots.R              # 3. summarize cross validation
 test-parallel.R         # check the parallel backend on this platform
 R/
   ├── wrappers.R        # model wrappers and the EDDS optimizer
+  ├── cluster.R         # worker cluster setup, shared by the optimizer and cv-plots.R
   ├── obj_fun.R         # objective functions, edit this to add your own
   ├── metrics.R         # goodness-of-fit metrics
   └── test-metrics.R    # optional check of metrics.R against reference implementation (hydroGOF)
@@ -313,9 +314,10 @@ the [hydroGOF](https://cran.r-project.org/package=hydroGOF) package.
 
 The optimizer spreads its objective function evaluations across a cluster of
 worker processes, and cv-plots.R builds a second cluster for its bootstrap. Both
-use FORK on Linux and macOS and PSOCK on Windows. A PSOCK worker starts from an
-empty session, so everything it needs has to be loaded on the worker explicitly,
-and that is where the two backends diverge in practice.
+get their cluster from `R/cluster.R`, which uses FORK on Linux and macOS and
+PSOCK on Windows. A PSOCK worker starts from an empty session, so everything it
+needs has to be loaded on the worker explicitly, and that is where the two
+backends diverge in practice.
 
 `test-parallel.R` checks that layer on its own: the right cluster type for the
 platform, workers that can load the local `box` modules and the compiled

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NWRFC Autocalibration Framework
 
+[![CI](https://github.com/NOAA-NWRFC/nwsrfs-hydro-autocalibration/actions/workflows/ci.yml/badge.svg)](https://github.com/NOAA-NWRFC/nwsrfs-hydro-autocalibration/actions/workflows/ci.yml)
+
 ## Description
 This repository contains a version of the Northwest River Forecast Center (NWRFC) autocalibration tool for parameterizing the National Weather Service River Forecast System (NWSRFS) models using an evolving dynamically dimensioned search (EDDS). NWSRFS, originally developed in the late 1970s, remains a core component of the NWS Community Hydrologic Prediction System (CHPS).  This framework supports simultaneous calibration of a suite of NWSRFS models across multiple zones, including: SAC-SMA, SNOW-17, Unit Hydrograph, LAG-K, CHANLOSS, and CONS_USE.  See the [NWSRFS documentation](https://www.weather.gov/owp/oh_hrl_nwsrfs_users_manual_htm_xrfsdocpdf) for more detail on each individual model.
 
@@ -80,6 +82,7 @@ The three scripts you run directly live at the top level. Shared functions live 
 run-controller.R        # 1. calibrate
 postprocess.R           # 2. simulate and plot the calibrated parameters
 cv-plots.R              # 3. summarize cross validation
+test-parallel.R         # check the parallel backend on this platform
 R/
   ├── wrappers.R        # model wrappers and the EDDS optimizer
   ├── obj_fun.R         # objective functions, edit this to add your own
@@ -122,6 +125,7 @@ The `run-controller.R` script is run to create an optimized parameter file (`par
     usage: run-controller.R [--] [--help] [--por] [--overwrite] [--lite]
           [--dir DIR] [--basin BASIN] [--objfun OBJFUN] [--optimizer
           OPTIMIZER] [--cvfold CVFOLD] [--num_cores NUM_CORES]
+          [--iterations ITERATIONS]
 
     Auto-calibration run controller
 
@@ -140,6 +144,9 @@ The `run-controller.R` script is run to create an optimized parameter file (`par
       -c, --cvfold      CV fold to run (integer 1-4) [default: none]
       -n, --num_cores   Number of cores to allocate for run, FULL uses all
                         available cores -2 [default: FULL]
+      -i, --iterations  Override the optimizer iteration count, for smoke
+                        tests only, a calibration this short is not usable
+                        [default: none]
 
 
 **Example:**
@@ -155,7 +162,7 @@ The `run-controller.R` script is run to create an optimized parameter file (`par
 - Light run (half the number of optimizer iterations): use `--lite`. Note that this will take less real time to run but may result in a lower quality parameter set. 
 - To overwrite last results directory, i.e. don't increment the output directory: use `--overwrite` (ignored if no results exist).
 - To control number of utilized CPU cores: `--cores [#]` or `--cores FULL` (uses all available minus 2).
-- The number of iterations is set to 5000 (or 2500 for a lite run) and is intentionally not user editiable based on extensive testing of how many iterations will produce stable parameter sets. Note that it is still important to manage equally viable parameter sets (i.e. equifinal solutions) by setting appropriate ranges for optimized parameter sets. This is particularly important for multi zone basins. 
+- The number of iterations is 5000, or 2500 for a lite run, chosen from extensive testing of how many iterations produce stable parameter sets. Do not lower it for real work. `--iterations` exists only so the continuous integration tests can drive the full pipeline in seconds, and a run that short will not converge. Note that it is still important to manage equally viable parameter sets (i.e. equifinal solutions) by setting appropriate ranges for optimized parameter sets. This is particularly important for multi zone basins. 
 - Increasing the number of cores used will not speed up the calibration but may make the calibration converge faster or come to a better overall solution. 
 - The optimizer supports calibration with daily average, instantaneous, or both flow types.
 
@@ -301,6 +308,32 @@ the [hydroGOF](https://cran.r-project.org/package=hydroGOF) package.
     Rscript -e "install.packages('hydroGOF')"
     ./R/test-metrics.R
 ```
+
+## Testing
+
+The optimizer spreads its objective function evaluations across a cluster of
+worker processes, and cv-plots.R builds a second cluster for its bootstrap. Both
+use FORK on Linux and macOS and PSOCK on Windows. A PSOCK worker starts from an
+empty session, so everything it needs has to be loaded on the worker explicitly,
+and that is where the two backends diverge in practice.
+
+`test-parallel.R` checks that layer on its own: the right cluster type for the
+platform, workers that can load the local `box` modules and the compiled
+`nwsrfsr` package, and a distinct L'Ecuyer-CMRG stream on each worker.
+
+```bash
+    ./test-parallel.R           # the backend this platform would use
+    ./test-parallel.R PSOCK     # force the Windows backend anywhere
+```
+
+The GitHub Actions workflow in `.github/workflows/ci.yml` runs on Linux, macOS,
+and Windows for every push and pull request. On each it runs `test-parallel.R`
+under both backends, then drives the whole pipeline, calibration through
+postprocessing through cross validation plots, on a one zone basin, a basin with
+a consumptive use zone, and a basin routing an upstream point through LAG-K. It
+passes `--iterations` to keep those runs to a few seconds, which is enough to
+exercise every parallel path but nowhere near enough to calibrate anything. A
+separate job checks `R/metrics.R` against hydroGOF.
 
 ## Credits and References
 

--- a/cv-plots.R
+++ b/cv-plots.R
@@ -8,8 +8,9 @@ box::use(
   crayon[blue, green, inverse, red],
   data.table[rbindlist],
   dplyr[bind_rows, filter, group_by, mutate, mutate_if, n, pull, select, slice_max, summarise],
+  ./R/cluster[make_worker_cluster],
   ./R/metrics[KGE, NSE, pbias, rPearson],
-  parallel[clusterCall, clusterEvalQ, clusterExport, clusterSetRNGStream, detectCores, makeCluster, stopCluster],
+  parallel[clusterCall, clusterEvalQ, clusterExport, clusterSetRNGStream, detectCores, stopCluster],
   readr[read_csv],
   stringr[str_detect, str_subset],
   tibble[as_tibble],
@@ -556,8 +557,7 @@ for(basin in basins){
     } else {
       detectCores()-2
     }
-  os_type <- if (.Platform$OS.type == "windows") "PSOCK" else "FORK"
-  my_cluster <- makeCluster(n_cores, type = os_type)
+  my_cluster <- make_worker_cluster(n_cores)
   # Seeding using L'Ecuyer-CMRG, isseed = NULL doc states initializes random process
   RNGkind("L'Ecuyer-CMRG")
   clusterSetRNGStream(cl = my_cluster, iseed = NULL)

--- a/run-controller.R
+++ b/run-controller.R
@@ -47,6 +47,7 @@ parser <- add_argument(parser, "--num_cores", default = "FULL", help = "Number o
 parser <- add_argument(parser, "--por", flag = TRUE, help = "Do a period of record run [default]")
 parser <- add_argument(parser, "--overwrite", flag = TRUE, help = "Don't create new results dir, overwrite the first exising one", short = "-ov")
 parser <- add_argument(parser, "--lite", flag = TRUE, help = "Testing run with 1/2 the total optimizer iteration")
+parser <- add_argument(parser, "--iterations", default = NA_integer_, help = "Override the optimizer iteration count, for smoke tests only, a calibration this short is not usable")
 
 
 args <- parse_args(parser)
@@ -75,6 +76,11 @@ overwrite <- args$overwrite
 lite <- args$lite
 n_cores <- args$num_cores
 dt_hours <- 6
+
+# NA means use the standard count, 5000, or 2500 with --lite
+t_iter <- as.integer(args$iterations)
+if (!is.na(t_iter) && t_iter < 1) stop("iterations must be a positive integer, exiting")
+if (is.na(t_iter)) t_iter <- if (lite) 2500L else 5000L
 
 # SET UP NUMBER OF CORES TO USE FOR OPTIMIZATION
 # if a number is passed then convert from string to number
@@ -125,7 +131,7 @@ settings_message <- paste0(settings_message, "Basin: ", basin, "\n")
 settings_message <- paste0(settings_message, "Input Directory: ", output_dir, "\n")
 settings_message <- paste0(settings_message, "Objective Function: ", obj_fun, "\n")
 settings_message <- paste0(settings_message, "Optimizer: ", optimizer, "\n")
-settings_message <- paste0(settings_message, "Iterations: ", ifelse(lite, "2500", "5000"), "\n")
+settings_message <- paste0(settings_message, "Iterations: ", t_iter, "\n")
 settings_message <- paste0(settings_message, "Cores Utilized for Parallelization: ", n_cores, "\n")
 settings_message <- paste0(settings_message, "Cross-Validation: ", cv, "\n")
 if (cv) {
@@ -342,7 +348,7 @@ ptm <- proc.time()
 
 out <- run_controller_edds(
   lower, upper, basin, dt_hours, default_pars, obs_daily, obs_inst,
-  forcing_raw, upflow, obj_fun, n_zones, cu_zones, n_cores, lite
+  forcing_raw, upflow, obj_fun, n_zones, cu_zones, n_cores, lite, t_iter
 )
 
 p_optimal <- out["p_best"][[1]]

--- a/test-parallel.R
+++ b/test-parallel.R
@@ -27,7 +27,8 @@
 
 box::use(
   parallel[clusterCall, clusterEvalQ, clusterExport, clusterSetRNGStream,
-           detectCores, makeCluster, stopCluster],
+           detectCores, stopCluster],
+  ./R/cluster[make_worker_cluster],
   ./R/metrics[NSE]
 )
 
@@ -44,7 +45,7 @@ check <- function(label, ok, detail = "") {
 cat("platform: ", R.version$platform, " (", .Platform$OS.type, ")\n", sep = "")
 cat("cores detected: ", detectCores(), "\n\n", sep = "")
 
-# The same choice ep_dds() and cv-plots.R make.
+# The type make_worker_cluster() should pick unprompted.
 expected <- if (.Platform$OS.type == "windows") "PSOCK" else "FORK"
 
 forced <- commandArgs(trailingOnly = TRUE)[1]
@@ -57,19 +58,23 @@ if (!is.na(forced)) {
   os_type <- forced
   cat("forcing ", os_type, " (platform default is ", expected, ")\n\n", sep = "")
 } else {
-  os_type <- expected
-  check(paste0("cluster type is ", expected), identical(os_type, expected), os_type)
+  os_type <- NULL
 }
 
 # Two workers is enough to tell a per-worker problem from a shared one, and it
 # fits the smallest runner.
 n_cores <- max(2, min(2, detectCores()))
 
-cat("\n=== worker startup ===\n")
-my_cluster <- makeCluster(n_cores, type = os_type)
+cat("=== worker startup ===\n")
+# Through the same helper the optimizer and cv-plots.R use, so the setup options
+# under test are the ones they actually get.
+my_cluster <- make_worker_cluster(n_cores, type = os_type)
 on.exit(try(stopCluster(my_cluster), silent = TRUE), add = TRUE)
+actual <- if (inherits(my_cluster[[1]], "forknode")) "FORK" else "PSOCK"
 check("cluster started", inherits(my_cluster, "cluster"),
-      paste(n_cores, os_type, "workers"))
+      paste(n_cores, actual, "workers"))
+check(paste0("cluster type is ", if (is.null(os_type)) expected else os_type),
+      identical(actual, if (is.null(os_type)) expected else os_type), actual)
 
 RNGkind("L'Ecuyer-CMRG")
 clusterSetRNGStream(cl = my_cluster, iseed = NULL)

--- a/test-parallel.R
+++ b/test-parallel.R
@@ -1,0 +1,148 @@
+#!/usr/bin/env Rscript
+
+# Checks the parallel backend that ep_dds() in R/wrappers.R and the bootstrap in
+# cv-plots.R rely on. Both pick FORK on Linux and macOS and PSOCK on Windows,
+# then bootstrap each worker by hand: set the working directory, load the local
+# box modules, and export the wrapper functions. A PSOCK worker starts from an
+# empty session, so anything the master picked up implicitly has to be loaded
+# again on the worker. That is the part that breaks on Windows, and this script
+# exercises it without waiting for a full calibration.
+#
+# Run it from the repository root:
+#
+#   Rscript test-parallel.R
+#
+# PSOCK is the strict case, so it is worth running on Linux and macOS too rather
+# than waiting for a Windows machine to disagree. Pass the type to force it:
+#
+#   Rscript test-parallel.R PSOCK
+#
+# It lives beside run-controller.R rather than under R/ on purpose. box resolves
+# a relative module against the directory of the script that asks for it, so
+# `./R/metrics` only resolves for a caller at the repository root, which is where
+# the worker bootstrap being tested runs from.
+#
+# Written by Cameron Bracken and Geoffrey Walters (2025)
+# Please see the LICENSE file for license information
+
+box::use(
+  parallel[clusterCall, clusterEvalQ, clusterExport, clusterSetRNGStream,
+           detectCores, makeCluster, stopCluster],
+  ./R/metrics[NSE]
+)
+
+failures <- 0
+checks <- 0
+
+check <- function(label, ok, detail = "") {
+  checks <<- checks + 1
+  if (!isTRUE(ok)) failures <<- failures + 1
+  cat(sprintf("  %-46s %s%s\n", label, if (isTRUE(ok)) "ok" else "FAIL",
+              if (nzchar(detail)) paste0("  (", detail, ")") else ""))
+}
+
+cat("platform: ", R.version$platform, " (", .Platform$OS.type, ")\n", sep = "")
+cat("cores detected: ", detectCores(), "\n\n", sep = "")
+
+# The same choice ep_dds() and cv-plots.R make.
+expected <- if (.Platform$OS.type == "windows") "PSOCK" else "FORK"
+
+forced <- commandArgs(trailingOnly = TRUE)[1]
+if (!is.na(forced)) {
+  forced <- toupper(forced)
+  if (!forced %in% c("FORK", "PSOCK")) stop("cluster type must be FORK or PSOCK")
+  if (forced == "FORK" && .Platform$OS.type == "windows") {
+    stop("Windows has no FORK cluster, nothing to force")
+  }
+  os_type <- forced
+  cat("forcing ", os_type, " (platform default is ", expected, ")\n\n", sep = "")
+} else {
+  os_type <- expected
+  check(paste0("cluster type is ", expected), identical(os_type, expected), os_type)
+}
+
+# Two workers is enough to tell a per-worker problem from a shared one, and it
+# fits the smallest runner.
+n_cores <- max(2, min(2, detectCores()))
+
+cat("\n=== worker startup ===\n")
+my_cluster <- makeCluster(n_cores, type = os_type)
+on.exit(try(stopCluster(my_cluster), silent = TRUE), add = TRUE)
+check("cluster started", inherits(my_cluster, "cluster"),
+      paste(n_cores, os_type, "workers"))
+
+RNGkind("L'Ecuyer-CMRG")
+clusterSetRNGStream(cl = my_cluster, iseed = NULL)
+
+# Byte for byte the bootstrap ep_dds() performs, so a failure here is a failure
+# there. A FORK worker inherits all of this and a PSOCK worker does not.
+master_wd <- getwd()
+clusterExport(my_cluster, "master_wd", envir = environment())
+boot <- try(
+  clusterEvalQ(my_cluster, {
+    setwd(master_wd)
+    box::use(
+      stats[runif, rnorm, setNames],
+      dplyr[filter, select, summarise, group_by, ungroup, mutate,
+            lead, right_join, bind_rows],
+      data.table[as.data.table, data.table, merge.data.table, copy,
+                 rbindlist, nafill],
+      tibble[as_tibble],
+      tidyr[fill],
+      ./R/metrics[NSE, pbias, rPearson, KGE],
+      nwsrfsr[sac_snow_uh, sac_snow_uh_lagk, lagk, chanloss,
+              consuse, fa_nwrfc],
+      obj_funs = ./R/obj_fun
+    )
+    TRUE
+  }),
+  silent = TRUE
+)
+check("workers loaded local and package modules", !inherits(boot, "try-error"),
+      if (inherits(boot, "try-error")) trimws(as.character(boot)) else "")
+
+# The working directory the modules were resolved against.
+wds <- unlist(clusterCall(my_cluster, getwd))
+check("workers share the master working directory",
+      all(normalizePath(wds) == normalizePath(master_wd)))
+
+cat("\n=== worker execution ===\n")
+# A function defined here and shipped to the workers. Under PSOCK it arrives
+# without its enclosing environment and resolves `NSE` against the worker's
+# global environment, which is what the box::use above populated.
+worker_task <- function() {
+  set.seed(NULL)
+  obs <- c(10, 12, 9, 14, 11, 13, 8, 15)
+  sim <- obs * 1.1
+  list(pid = Sys.getpid(), seed = globalenv()$.Random.seed, nse = NSE(sim, obs))
+}
+res <- try(clusterCall(my_cluster, worker_task), silent = TRUE)
+check("workers ran a local module function", !inherits(res, "try-error"),
+      if (inherits(res, "try-error")) trimws(as.character(res)) else "")
+
+if (!inherits(res, "try-error")) {
+  worker_nse <- sapply(res, function(x) x$nse)
+  master_nse <- NSE(c(10, 12, 9, 14, 11, 13, 8, 15) * 1.1,
+                    c(10, 12, 9, 14, 11, 13, 8, 15))
+  check("worker results match the master",
+        isTRUE(all.equal(unname(worker_nse), rep(master_nse, length(worker_nse)))),
+        sprintf("%.6f", master_nse))
+
+  # run-controller.R aborts the whole calibration when two workers report the
+  # same stream, so check it here where the message can be useful.
+  seeds <- sapply(res, function(x) paste(x$seed, collapse = ","))
+  check("each worker has a distinct RNG stream",
+        length(unique(seeds)) == length(seeds),
+        sprintf("%d streams across %d workers", length(unique(seeds)), length(seeds)))
+
+  kinds <- unique(sapply(res, function(x) x$seed[1]))
+  check("workers use L'Ecuyer-CMRG", all(kinds %% 100 == 7),
+        paste(kinds, collapse = ", "))
+}
+
+cat("\n=== teardown ===\n")
+stopped <- try(stopCluster(my_cluster), silent = TRUE)
+check("cluster stopped", !inherits(stopped, "try-error"))
+
+cat(sprintf("\n%d checks, %d failures\n", checks, failures))
+if (failures > 0) quit(status = 1)


### PR DESCRIPTION
Stacked on #11. Review that one first; this branch only adds the CI work on top.

## Why

`ep_dds()` and the `cv-plots.R` bootstrap each build their own cluster, FORK on Linux and macOS, PSOCK on Windows. Nothing checked that the PSOCK path kept working after the Windows changes in #8, and nothing would catch a regression in it.

## What runs

`.github/workflows/ci.yml`, matrix over `ubuntu-latest`, `macos-latest` and `windows-latest` with `fail-fast: false` so one platform failing still reports the others:

- `test-parallel.R` under the platform default backend, then again forced to PSOCK on Linux and macOS. A worker bootstrap that only works under FORK now fails on every platform, not just the Windows runner.
- Full pipeline on 1zone FSSO3: calibrate, four CV folds, `postprocess.R`, `cv-plots.R`. The last one matters because it builds a second cluster independent of the optimizer's.
- 2zone SFLN2 (consumptive use and channel loss) and SAKW1 (LAG-K with an upstream point), reaching the model paths FSSO3 does not.
- A separate Ubuntu job checking `R/metrics.R` against hydroGOF, which stays a check only dependency.

R is pinned to 4.6.1 to match `renv.lock`, and `setup-renv` caches the library. The whole sequence including the output assertions runs in about 90 seconds warm.

## New file

`test-parallel.R` covers the backend on its own: cluster type for the platform, workers loading the local `box` modules and the compiled `nwsrfsr` package, and a distinct L'Ecuyer-CMRG stream per worker. When it fails the message points at worker startup rather than at whichever calibration happened to run first.

It takes an optional type argument, `./test-parallel.R PSOCK`, so the Windows backend can be exercised anywhere.

It sits at the repository root rather than under `R/` on purpose. `box` resolves a relative module against the directory of the script that asks for it, so `./R/metrics` only resolves for a caller at the root, which is where the bootstrap being tested runs from.

## Framework changes

`run-controller.R` gains `--iterations`, which is what keeps the CI runs to a few seconds. It is documented as a smoke test switch. A run that short does not converge and is not usable for calibration; the 5000 and 2500 defaults are unchanged.

## Bug fix

`R/wrappers.R` used `dplyr::lag` in the consumptive use branch of `model_wrapper()` but never imported it, so every consuse basin failed with `could not find function "lag"` as soon as the objective function was evaluated. Pre-existing since the initial import, unrelated to the dependency work in #11. Fixed in both the top level import and the worker bootstrap. SFLN2 in the workflow covers it.

## Note

The README badge will show no status until this reaches `main`.

## What CI found on Windows

The first run of this workflow failed on `windows-latest`, which is the point of it. Part way through the cross validation folds a `makePSOCKcluster` call hung for four minutes and died with `Cluster setup failed. 1 worker of 2 failed to connect`. The three clusters before it in the same job were fine, so it is intermittent rather than a hard break.

Since R 4.0 `makePSOCKcluster` starts every worker at once by default. When one fails to connect the master waits out the full connection timeout before giving up, taking the calibration with it. The second commit starts Windows workers one at a time instead, which costs about a second per run.

That commit also pulls the FORK/PSOCK choice out of `wrappers.R` and `cv-plots.R`, which each carried their own copy, into `R/cluster.R`. `test-parallel.R` now exercises that shared helper rather than a reimplementation of it.

All four jobs pass on the current head.
